### PR TITLE
Update README license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ Contributing
 Contributions to the Outgoing Transfer Verification Tool are welcome! Please feel free to submit pull requests, report bugs, or suggest features via the GitHub issues page.
 
 License
-This project is licensed under the GNU General Public License v3.0 - see the LICENSE file for details.
+This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.


### PR DESCRIPTION
## Summary
- update README license text to reference the GNU Affero General Public License v3.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f038cfe208328a8eb76098390c8c2