### PR TITLE
Fix duplicate CSV generation

### DIFF
--- a/verification_function.py
+++ b/verification_function.py
@@ -208,9 +208,8 @@ class TransferApp(tk.Tk):
 
     def submit(self):
         if self.check_missed_items():
-            manifest_number = self.manifest_entry.get() 
-            self.generate_csv(manifest_number) 
-            local_file_path, file_name = self.generate_csv(manifest_number) 
+            manifest_number = self.manifest_entry.get()
+            local_file_path, file_name = self.generate_csv(manifest_number)
             self.upload_to_sharepoint(local_file_path, file_name)
             messagebox.showinfo("Success", f"{manifest_number} verification.csv generated successfully!")
             self.destroy()


### PR DESCRIPTION
## Summary
- ensure `submit` only generates the CSV once and uses returned path when uploading

## Testing
- `python -m py_compile verification_function.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f037dc61c83289fd62470d3f35f6e