### PR TITLE
Maintain focus on tag entry after scanning

### DIFF
--- a/verification_function.py
+++ b/verification_function.py
@@ -207,6 +207,7 @@ class TransferApp(tk.Tk):
             self.handle_unrecognized_tag(tag)
 
         self.tag_entry.delete(0, tk.END)
+        self.tag_entry.focus_set()
 
 
     def handle_unrecognized_tag(self, tag):


### PR DESCRIPTION
## Summary
- when scanning, keep cursor focus on tag entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f0ba48dd08328837415ea94355e26