### PR TITLE
Make weight fetch concurrency configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ automatically when executed. If the variables are not set, any values entered in
 
 Note: Do not share your API keys or credentials within your code when publishing or sharing your project.
 
+Thread Pool Workers
+-------------------
+Package weight information is fetched concurrently using threads. The default
+number of worker threads is **10**, but this can be tuned by setting the
+`WEIGHT_FETCH_WORKERS` environment variable before running the script. Adjust
+this value based on your available network capacity and any API rate limits you
+need to respect.
+
 Dependencies
 All Python dependencies are listed in `requirements.txt`. Install them with:
 

--- a/verification_function.py
+++ b/verification_function.py
@@ -12,6 +12,10 @@ from auth_header import headers, username, password
 from office365.runtime.auth.user_credential import UserCredential
 from office365.sharepoint.client_context import ClientContext
 
+# Number of workers used when fetching package weights concurrently. Can be
+# overridden with the WEIGHT_FETCH_WORKERS environment variable.
+WEIGHT_FETCH_WORKERS = int(os.getenv("WEIGHT_FETCH_WORKERS", "10"))
+
 def get_transfers(api_endpoint, headers, logger):
     try:
         response = requests.get(api_endpoint, headers=headers)
@@ -155,7 +159,7 @@ class TransferApp(tk.Tk):
             self.logger.warning("No tags found in transfer data.")
 
         # Concurrently fetch weights and weight units for each tag
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=WEIGHT_FETCH_WORKERS) as executor:
             tag_details = {tag: executor.submit(fetch_weight_for_tag, tag, self.logger) for tag in tags}
 
         for tag, future in tag_details.items():


### PR DESCRIPTION
## Summary
- add `WEIGHT_FETCH_WORKERS` constant and use it with `ThreadPoolExecutor`
- document the new setting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f0ba32cc883289f89a71ea7660427