### PR TITLE
Use shared session for network calls

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,15 @@ if 'requests' not in sys.modules:
         raise RuntimeError('requests.get should be mocked in tests')
 
     requests_stub.get = dummy_get
+
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise RuntimeError('session.get should be mocked in tests')
+
+        def close(self):
+            pass
+
+    requests_stub.Session = DummySession
     sys.modules['requests'] = requests_stub
 
 # Stub out office365 modules if not installed so imports succeed

--- a/tests/test_fetch_weight_for_tag.py
+++ b/tests/test_fetch_weight_for_tag.py
@@ -8,7 +8,7 @@ def test_fetch_weight_for_tag_success():
     mock_resp = MagicMock()
     mock_resp.status_code = 200
     mock_resp.json.return_value = [{"weight": 5, "weight_unit": "g"}]
-    with patch("verification_function.requests.get", return_value=mock_resp) as mock_get:
+    with patch("verification_function.session.get", return_value=mock_resp) as mock_get:
         logger = logging.getLogger("test")
         weight, unit = fetch_weight_for_tag("TAG1", logger)
     mock_get.assert_called_once()
@@ -20,7 +20,7 @@ def test_fetch_weight_for_tag_empty_response(caplog):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
     mock_resp.json.return_value = []
-    with patch("verification_function.requests.get", return_value=mock_resp):
+    with patch("verification_function.session.get", return_value=mock_resp):
         logger = logging.getLogger("test")
         with caplog.at_level(logging.WARNING):
             weight, unit = fetch_weight_for_tag("TAG123", logger)
@@ -33,7 +33,7 @@ def test_fetch_weight_for_tag_error(caplog):
     mock_resp = MagicMock()
     mock_resp.status_code = 404
     mock_resp.text = "not found"
-    with patch("verification_function.requests.get", return_value=mock_resp):
+    with patch("verification_function.session.get", return_value=mock_resp):
         logger = logging.getLogger("test")
         with caplog.at_level(logging.ERROR):
             weight, unit = fetch_weight_for_tag("TAG404", logger)

--- a/tests/test_get_transfers.py
+++ b/tests/test_get_transfers.py
@@ -9,7 +9,7 @@ def test_get_transfers_success():
     mock_resp.status_code = 200
     expected_data = [{"id": 1}]
     mock_resp.json.return_value = expected_data
-    with patch("verification_function.requests.get", return_value=mock_resp) as mock_get:
+    with patch("verification_function.session.get", return_value=mock_resp) as mock_get:
         logger = logging.getLogger("test")
         result = get_transfers("http://example.com/api", {}, logger)
     mock_get.assert_called_once_with("http://example.com/api", headers={})
@@ -20,7 +20,7 @@ def test_get_transfers_failure(caplog):
     mock_resp = MagicMock()
     mock_resp.status_code = 500
     mock_resp.text = "server error"
-    with patch("verification_function.requests.get", return_value=mock_resp):
+    with patch("verification_function.session.get", return_value=mock_resp):
         logger = logging.getLogger("test")
         with caplog.at_level(logging.ERROR):
             result = get_transfers("http://bad.api", {}, logger)

--- a/verification_function.py
+++ b/verification_function.py
@@ -8,13 +8,18 @@ from tkinter import messagebox
 import tkinter as tk
 
 import requests
+import atexit
+
+# Use a shared requests session for API calls
+session = requests.Session()
+atexit.register(session.close)
 from auth_header import headers, username, password
 from office365.runtime.auth.user_credential import UserCredential
 from office365.sharepoint.client_context import ClientContext
 
 def get_transfers(api_endpoint, headers, logger):
     try:
-        response = requests.get(api_endpoint, headers=headers)
+        response = session.get(api_endpoint, headers=headers)
         if response.status_code != 200:
             print("Error status code:", response.status_code)
             logger.error(f"Error: {response.status_code} {response.text}")
@@ -29,7 +34,7 @@ def get_transfers(api_endpoint, headers, logger):
 def fetch_weight_for_tag(tag, logger):
     api_endpoint = f"https://api.canix.com/api/v1/packages?where=tag=%27{tag}%27"
     try:
-        response = requests.get(api_endpoint, headers=headers)
+        response = session.get(api_endpoint, headers=headers)
         if response.status_code == 200:
             data = response.json()
             if not data:


### PR DESCRIPTION
## Summary
- create a module-level `requests` session and close it on exit
- use the shared session for `get_transfers` and `fetch_weight_for_tag`
- adjust tests to patch `session.get`
- extend the request stub to include a `Session`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f0b816a088328b2a8515410bd8216